### PR TITLE
更新文章图片地址

### DIFF
--- a/source/_posts/fluid-write.md
+++ b/source/_posts/fluid-write.md
@@ -161,16 +161,16 @@ Fluid 内置了许多 Tag 组件，包含便签、行内标签（已知不会出
 众所周知，**博客好不好看，配图占一半**。这里给大家推荐几个我常用找配图的地方。**另外，请遵循相关网站的版权协议。**
 
 ### Wallpaper Hub
-![Wallpaper Hub](https://cdn.vince.pub/blog-file/photo/2020-04-17_175244.png)
+![Wallpaper Hub](https://cdn.jsdelivr.net/gh/vinceying/static@main/images/blog_fluid/2020-04-17_175244.png)
 
 **[点击跳转到 Wallpaper Hub](https://wallpaperhub.app/)**
 
 ### Wallhaven
-![Wallhaven](https://cdn.vince.pub/blog-file/photo/2020-04-17_174841.png)
+![Wallhaven](https://cdn.jsdelivr.net/gh/vinceying/static@main/images/blog_fluid/2020-04-17_174841.png)
 
 **[点击跳转到 Wallhaven](https://wallhaven.cc/)**
 
 ### Unsplash
-![Unsplash](https://cdn.vince.pub/blog-file/photo/2020-05-14_000557.png)
+![Unsplash](https://cdn.jsdelivr.net/gh/vinceying/static@main/images/blog_fluid/2020-05-14_000557.png)
 
 **[点击跳转到 Unsplash](https://unsplash.com/)**

--- a/source/_posts/hexo-static.md
+++ b/source/_posts/hexo-static.md
@@ -24,7 +24,7 @@ excerpt: 择一个合适的托管平台对于博客来说十分重要，可以�
 
 ## 常见托管平台
 
-![节点](https://cdn.vince.pub/blog-file/photo/2fc062cb2.svg)
+![节点](https://cdn.jsdelivr.net/gh/vinceying/static@main/images/blog_fluid/static_list.svg)
 
 ### Github Pages
 


### PR DESCRIPTION
因为原来服务器到期和在做调整，把图片地址更换到 jsdelivr。